### PR TITLE
Socket prevention

### DIFF
--- a/features/PreventSockets.cpp
+++ b/features/PreventSockets.cpp
@@ -1,0 +1,65 @@
+/**
+ * @description Prevent the fact you can socket an item, to prevent miss click socketing
+ * @Author Jaenster
+ */
+
+#include "headers/feature.h"
+#include "headers/common.h"
+#include "headers/hook.h"
+#include "headers/remote.h"
+namespace PreventSockets {
+
+    unsigned int __fastcall getSetting() {
+        return Settings["preventSockets"];
+    }
+
+    __declspec(naked) unsigned int __fastcall myIntercept() {
+        static ASMPTR back = 0x48448f;
+        __asm {
+            // Original code // 3b c6 1b c0
+            cmp        eax, ESI
+            sbb        eax, eax
+
+            // since ESI is not needed anymore we can use it
+            mov esi, eax // backup eax
+            
+            call getSetting
+            xchg esi, eax
+
+            // esi got value of setting
+            // eax got actual number of open sockets on target
+            test esi, esi
+            jz Continue
+
+            // fake that we have zero available sockets
+            mov eax, 0 
+
+        Continue:
+
+            // Last statement we overriden with the jump
+            pop        edi // 5f
+            JMP back
+        }
+    }
+
+    class : public Feature {
+    public:
+        void init() {
+            MemoryPatch(0x48448a) << JUMP(myIntercept);
+        }
+
+        bool keyEvent(DWORD keyCode, bool down, DWORD flags) {
+            switch (keyCode) {
+            case VK_INSERT:
+                bool isActive = (Settings["preventSockets"] = !Settings["preventSockets"]);
+                gamelog << "Preventing sockets: " << COLOR(isActive ? 2 : 1) << (isActive ? "on": "off") << std::endl;
+                SaveSettings();
+                return false;
+            }
+
+            return true;
+        }
+
+    } feature;
+
+}

--- a/features/Settings.cpp
+++ b/features/Settings.cpp
@@ -105,6 +105,14 @@ std::vector<std::vector<DialogToggleInfo*>> SettingsColumns = {
                 Settings["noPickup"] = !Settings["noPickup"];
                 SaveSettings();
             }),
+        new DialogToggleInfo(L"Prevent socketing",
+            []() -> std::wstring {
+                return Settings["preventSockets"] ? L"\u00FFc2On" : L"\u00FFc1Off";
+            }, [](MouseButton button, bool down) -> void {
+                if (down) return;
+                Settings["preventSockets"] = !Settings["preventSockets"];
+                SaveSettings();
+            }),
         nullptr, // Empty Gap
         new DialogToggleInfo(L"Repeatable Respec Quest",
             []() -> std::wstring {
@@ -198,6 +206,7 @@ std::vector<std::vector<DialogToggleInfo*>> SettingsColumns = {
                 Settings["alwaysD3DStartFull"] = !Settings["alwaysD3DStartFull"];
                 SaveSettings();
             }),
+        nullptr, // Empty Gap
         nullptr, // Empty Gap
         new DialogToggleInfo(L"Draw Color Swatch",
             []() -> std::wstring {


### PR DESCRIPTION
As stated,

To avoid people missclicking on items with a socketable in hand.