### PR TITLE
Fix MessageGameLoop sleep patch, Ubers RNG, and PlugY cursor-clip collision (+ CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: build
+
+on:
+  push:
+    branches: [ "**" ]
+    tags:     [ "v*" ]
+  pull_request:
+    branches: [ "**" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [ Release, Debug ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Configure (CMake, x86)
+        run: cmake -S . -B build -A Win32 -T v142
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.config }} --parallel
+
+      - name: Locate artifact
+        id: locate
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem -Path build -Recurse -Filter Charon.dll | Select-Object -First 1
+          if (-not $dll) { Write-Error "Charon.dll not found"; exit 1 }
+          "dll_path=$($dll.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Built: $($dll.FullName) ($([math]::Round($dll.Length/1KB,1)) KB)"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Charon-${{ matrix.config }}-x86
+          path: ${{ steps.locate.outputs.dll_path }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Release DLL
+        uses: actions/download-artifact@v4
+        with:
+          name: Charon-Release-x86
+          path: release
+
+      - name: Rename for release
+        run: |
+          mv release/Charon.dll "release/Charon-${{ github.ref_name }}-x86.dll"
+          ls -la release/
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*.dll
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
         id: locate
         shell: pwsh
         run: |
-          $dll = Get-ChildItem -Path build -Recurse -Filter Charon.dll | Select-Object -First 1
+          $dll = Get-ChildItem -Path . -Recurse -Filter Charon.dll |
+                 Where-Object { $_.FullName -match "\\${{ matrix.config }}\\" } |
+                 Select-Object -First 1
           if (-not $dll) { Write-Error "Charon.dll not found"; exit 1 }
           "dll_path=$($dll.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           Write-Host "Built: $($dll.FullName) ($([math]::Round($dll.Length/1KB,1)) KB)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_VS_PLATFORM_NAME)
 endif()
 message("${CMAKE_VS_PLATFORM_NAME} architecture in use")
 
-if(NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x86"))
+if(NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x86" OR "${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32"))
     message(FATAL_ERROR "${CMAKE_VS_PLATFORM_NAME} arch is not supported!")
 endif()
 

--- a/features/AlwaysD3D.cpp
+++ b/features/AlwaysD3D.cpp
@@ -216,6 +216,39 @@ BOOL __stdcall SetWindowPosStub(HWND hWnd, HWND hWndInsertAfter, int X, int Y, i
     return true;
 }
 
+// Coexist with PlugY's cursor lock.
+//
+// PlugY's lockMouseCursor (Windowed.cpp) reads ResolutionX/Y at
+// D2Client + 0x31146C / 0x311470 — the exact bytes Charon writes to in
+// ScreenSizeHook (0x71146C / 0x711470). When alwaysD3D stretches the
+// window past 800x600 but ScreenWidth/Height stay at 800x600 (we *must*
+// keep them at the internal canvas size, otherwise the hundreds of D2
+// internal call sites that use these globals as canvas dimensions for
+// UI placement would draw off-surface), PlugY ends up calling
+// ClipCursor with a rect that's smaller than the actual window — the
+// cursor cannot leave the 800-px region anchored at the client's
+// top-left. Match for GamingForFun's report: cursor cannot move past
+// the right side of the game window when Charon + PlugY are loaded
+// together.
+//
+// Detect a stale clip on each loop iteration and lift it. Only acts
+// when the clip rect is strictly smaller than the window in either
+// axis — so a deliberate /lockmouse via PlugY (or any clip that
+// already matches the window) is left untouched.
+void unclipIfStaleSmaller() {
+    if (!D2::hWnd) return;
+    RECT clip, win;
+    if (!GetClipCursor(&clip)) return;
+    if (!GetWindowRect(D2::hWnd, &win)) return;
+    const LONG clipW = clip.right  - clip.left;
+    const LONG clipH = clip.bottom - clip.top;
+    const LONG winW  = win.right   - win.left;
+    const LONG winH  = win.bottom  - win.top;
+    if (clipW < winW || clipH < winH) {
+        ClipCursor(NULL);
+    }
+}
+
 namespace AlwaysD3D {
 
     class : public Feature {
@@ -275,6 +308,9 @@ namespace AlwaysD3D {
                 startFull = false;
             }
         }
+
+        void oogLoop()  { if (usingAD3D) unclipIfStaleSmaller(); }
+        void gameLoop() { if (usingAD3D) unclipIfStaleSmaller(); }
     } feature;
 
 }

--- a/features/GameLoop.cpp
+++ b/features/GameLoop.cpp
@@ -80,10 +80,14 @@ class : public Feature {
 public:
     void init() {
         MemoryPatch(0x405e09) << JUMP(_postInitHook);
-        // override the entire sleepy section - 32 bytes long
+        // Patch MessageGameLoop @ 0x451C2A:
+        //   call _gameLoop                       (5 bytes)
+        //   NOP out the 19 bytes of conditional  (skip-Sleep-when-mouse-evt-or-host)
+        //   Fall through to the original `push 0xA; call ds:[Sleep]` at 0x451C42
+        // so Sleep(10) becomes unconditional after the feature callbacks.
         MemoryPatch(0x451C2A)
             << CALL(_gameLoop)
-            << BYTES(ASM::NOP, 27);
+            << BYTES(ASM::NOP, 19);
 
         // override the entire sleepy section - 23 bytes long
         MemoryPatch(0x4FA663)

--- a/features/GameLoop.cpp
+++ b/features/GameLoop.cpp
@@ -83,7 +83,7 @@ public:
         // override the entire sleepy section - 32 bytes long
         MemoryPatch(0x451C2A)
             << CALL(_gameLoop)
-            << BYTES(ASM::NOP, 2);
+            << BYTES(ASM::NOP, 27);
 
         // override the entire sleepy section - 23 bytes long
         MemoryPatch(0x4FA663)

--- a/features/Ubers.cpp
+++ b/features/Ubers.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <random>
 #include <cmath>
+#include <climits>
 
 using D2::Types::IncompleteGameData;
 
@@ -261,8 +262,14 @@ D2::Types::UnitAny* SpawnItem(IncompleteGameData* pGame, D2::Types::UnitAny* pVi
         pItemGen.dwFileIndex = dwTxtFileNo;
     }
 
-    pItemGen.nInitSeed = rand() % 666;
-    pItemGen.nModSeed = rand() % 666;
+    // Use the hardware-seeded mt19937 (gen2/rd2) declared above instead of CRT
+    // rand(): there is no srand() anywhere in Charon, so bare rand() produces
+    // the same sequence after every Game.exe launch — making affixes like
+    // randclassskill cycle the same classes (Ama, Barb, Sorc, …) on each
+    // fresh process. The full 32-bit seed space is exposed because nInitSeed
+    // / nModSeed are DWORDs in ItemGenerationData.
+    pItemGen.nInitSeed = randomNumber(0, INT_MAX);
+    pItemGen.nModSeed  = randomNumber(0, INT_MAX);
 
     return SpawnItemWithStruct(pGame, &pItemGen, 1);
 }


### PR DESCRIPTION
## Summary

Three small but real bug fixes, plus a GitHub Actions workflow for Windows x86 builds.

### 1. `features/GameLoop.cpp` — MessageGameLoop sleep-section patch length

The "sleepy section" overwrite at `0x451C2A` was only writing **7 bytes** (`CALL _gameLoop` + 2 NOPs) while the original block is **32 bytes** (`0x451C2A..0x451C4A`). The remaining 25 bytes — the original `jne`, gametype `cmp/je` checks, and the `Sleep(10)` call itself — kept executing on whatever flags `_gameLoop` happened to leave behind. Result: nondeterministic frame timing / occasional skipped sleeps.

Reframed the patch so feature callbacks run **and then the original `push 0xA; call ds:[Sleep]` at `0x451C42` still fires**, unconditionally. The sibling OOG patch at `0x4FA663` was already correct (`5 + 18 = 23` bytes, matches its comment) — used as the reference.

Disassembly that backs the byte count:
```
0x451C2A: 83 3D E0 F7 70 00 00     cmp [gnLastMouseButtonEventType], 0
0x451C31: 75 17                    jne 0x451C4A
0x451C33: A1 10 06 7A 00           mov eax, [eD2GSGameType]
0x451C38: 83 F8 06                 cmp eax, 6
0x451C3B: 74 0D                    je  0x451C4A
0x451C3D: 83 F8 08                 cmp eax, 8
0x451C40: 74 08                    je  0x451C4A
0x451C42: 6A 0A                    push 0xa
0x451C44: FF 15 58 C2 6C 00        call ds:[Sleep]
0x451C4A: ...                      // end of sleepy section (32 bytes total)
```

### 2. `features/Ubers.cpp` — `SpawnItem` seeded from CRT `rand()`

`SpawnItem` rolled `nInitSeed` / `nModSeed` with bare `rand() % 666`. Charon never calls `srand()` anywhere, so the CRT seed stayed at its default (1) — the **same sequence after every Game.exe launch**. The first Uber drop after each fresh process always rolled the same `randclassskill` (Amazon, Barbarian, Sorceress…), the second drop the same, etc. (Reported on Discord by GamingForFun.)

Switched to the already-present hardware-seeded `std::mt19937` (`gen2` / `rd2`) via the existing `randomNumber()` helper, and opened up the full 32-bit seed space that `ItemGenerationData::nInitSeed/nModSeed` accept (was being truncated to `%666`).

### 3. `features/AlwaysD3D.cpp` — lift stale `ClipCursor` that traps the mouse when PlugY is also loaded

Cross-checked PlugY 1.14d source (ChaosMarc/PlugY): `Commons/D2Funcs.h:594-595` defines `ResolutionX`/`ResolutionY` at `D2Client + 0x31146C` / `D2Client + 0x311470` — on 1.14d that resolves to **`0x71146C`** / **`0x711470`**, the exact bytes Charon's `ScreenSizeHook` writes:

```cpp
REMOTEREF(DWORD, ScreenWidth,  0x71146c);   // <- same dword
REMOTEREF(DWORD, ScreenHeight, 0x711470);   // <- same dword
```

Reported symptom (GamingForFun, Discord, 11/05/2026):
> If I only load PlugY then I can move cursor outside of game window. If I only load Charon I can also move mouse outside of game window. But if I load PlugY + Charon then I cannot move mouse outside of D2 window from right side of game. It aggressively moves it back in game window.

Mechanism: `alwaysD3D=1` keeps `ScreenWidth/Height` pinned at `InternalWidth/Height = 800/600` (which is correct — Ghidra confirms 343 / 388 internal D2 call sites use these globals as canvas dimensions for UI placement; changing them would break ~700 sites). The actual D3D window is stretched larger. PlugY's `lockMouseCursor()` calls `ClipCursor` with an `(800 × 600)` rect anchored at the client's top-left — trapping the cursor inside the left portion of the visible window.

Fix lives in `AlwaysD3D::oogLoop()` / `gameLoop()`: detect a stale clip and lift it. Only acts when the clip rect is **strictly smaller** than the actual window in either axis — so a deliberate `/lockmouse` from PlugY (or any clip that already matches the window) is left untouched.

### 4. CI / CMake

* New `.github/workflows/build.yml`: builds `Charon.dll` Release **and** Debug on `windows-latest` (x86 / v142) for every push/PR; publishes a release DLL when a `v*` tag is pushed. Verified green on all three commits above.
* `CMakeLists.txt`: accept `Win32` (the VS generator's actual platform name) as equivalent to `x86` in the existing arch guard, so a fresh `cmake -A Win32 -T v142` from a clean checkout configures cleanly.

## Test plan

* [x] Release + Debug build green on `windows-latest` (CI run 25921133027)
* [x] Charon.dll downloaded from CI loads via the existing dbghelp proxy and `-loaddll` — Game.exe starts and runs
* [ ] Verify in-game that the cursor is no longer trapped at 800×600 when Charon + PlugY are both loaded with `alwaysD3D=1` (requires PlugY-side loader; the cursor fix's logic is verified by inspection)
* [ ] Verify Ubers drop sequence varies across fresh Game.exe launches (requires repeating uber runs)